### PR TITLE
Issue #66

### DIFF
--- a/src/ui/custom-elements.js
+++ b/src/ui/custom-elements.js
@@ -36,15 +36,17 @@ function preactCustomElement(Comp, observedAttributes = []) {
       this.renderWithPreact();
     }
     renderWithPreact() {
-      this.shadow = this.attachShadow({ mode: "open" });
-      this.renderedEl = render(
-        h(Comp, { customElement: this }),
-        this.shadow,
-        this.renderedEl
-      );
-      const style = document.createElement("style");
-      style.textContent = styles.toString();
-      this.shadow.appendChild(style);
+      if (!this.shadowRoot) {
+        this.shadow = this.attachShadow({ mode: "open" });
+        this.renderedEl = render(
+          h(Comp, { customElement: this }),
+          this.shadow,
+          this.renderedEl
+        );
+        const style = document.createElement("style");
+        style.textContent = styles.toString();
+        this.shadow.appendChild(style);
+      }
     }
   };
 }


### PR DESCRIPTION
Following issue #66 I added a condition to check if a shadow root is already attached to the element and prevent the exception (https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow#exceptions). I tested it with our apps and it seems to work fine.

I don't know if the shadow root already being attached should be handled a different way like removing and recreating it or any other action. But this check seems to work, the import-map ui is rendered and styled correctly on first load and refresh.

![image](https://user-images.githubusercontent.com/15238295/159703551-85d7de1e-1d6d-444e-a664-d134ac7248a6.png)
 