### PR TITLE
chore: adjust UI of table list in imo status column

### DIFF
--- a/src/ui/import-map-overrides.css
+++ b/src/ui/import-map-overrides.css
@@ -128,13 +128,6 @@
   margin-top: 32px;
 }
 
-.imo-overrides-table tr td:first-child {
-  display: flex;
-  align-items: center;
-  padding-right: 32px;
-  position: relative;
-}
-
 .imo-needs-refresh {
   position: absolute;
   right: 8px;
@@ -145,6 +138,13 @@
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
+}
+
+.imo-status-wrapper {
+  display: flex;
+  align-items: center;
+  padding-right: 32px;
+  position: relative;
 }
 
 .imo-status {

--- a/src/ui/list/list.component.js
+++ b/src/ui/list/list.component.js
@@ -212,9 +212,11 @@ export default class List extends Component {
                 key={mod.moduleName}
               >
                 <td onClick={this.reload} role="button" tabIndex={0}>
-                  <div className="imo-status imo-next-override" />
-                  <div>Inline Override</div>
-                  <div className="imo-needs-refresh" />
+                  <div className="imo-status-wrapper">
+                    <div className="imo-status imo-next-override" />
+                    <div>Inline Override</div>
+                    <div className="imo-needs-refresh" />
+                </div>
                 </td>
                 <td>{mod.moduleName}</td>
                 <td>{toDomain(mod)}</td>
@@ -229,9 +231,11 @@ export default class List extends Component {
                 key={mod.moduleName}
               >
                 <td style={{ position: "relative" }}>
-                  <div className="imo-status imo-next-default" />
-                  <div>Default</div>
-                  <div className="imo-needs-refresh" />
+                  <div className="imo-status-wrapper">
+                    <div className="imo-status imo-next-default" />
+                    <div>Default</div>
+                    <div className="imo-needs-refresh" />
+                  </div>
                 </td>
                 <td>{mod.moduleName}</td>
                 <td>{toDomain(mod)}</td>
@@ -246,8 +250,10 @@ export default class List extends Component {
                 key={mod.moduleName}
               >
                 <td>
-                  <div className="imo-status imo-disabled-override" />
-                  <div>Override disabled</div>
+                  <div className="imo-status-wrapper">
+                    <div className="imo-status imo-disabled-override" />
+                    <div>Override disabled</div>
+                  </div>
                 </td>
                 <td>{mod.moduleName}</td>
                 <td>{toDomain(mod)}</td>
@@ -262,8 +268,10 @@ export default class List extends Component {
                 key={mod.moduleName}
               >
                 <td>
-                  <div className="imo-status imo-current-override" />
-                  <div>Inline Override</div>
+                  <div className="imo-status-wrapper">
+                    <div className="imo-status imo-current-override" />
+                    <div>Inline Override</div>
+                  </div>
                 </td>
                 <td>{mod.moduleName}</td>
                 <td>{toDomain(mod)}</td>
@@ -295,8 +303,10 @@ export default class List extends Component {
                 title="Automatically use dev version of certain npm libs"
               >
                 <td>
-                  <div className="imo-status imo-dev-lib-override" />
-                  <div>Dev Lib Override</div>
+                  <div className="imo-status-wrapper">
+                    <div className="imo-status imo-dev-lib-override" />
+                    <div>Dev Lib Override</div>
+                  </div>
                 </td>
                 <td>{mod.moduleName}</td>
                 <td>{toDomain(mod)}</td>
@@ -311,8 +321,10 @@ export default class List extends Component {
                 key={mod.moduleName}
               >
                 <td>
-                  <div className="imo-status imo-default-module" />
-                  <div>Default</div>
+                    <div className="imo-status-wrapper">
+                      <div className="imo-status imo-default-module" />
+                      <div>Default</div>
+                    </div>
                 </td>
                 <td>{mod.moduleName}</td>
                 <td>{toDomain(mod)}</td>
@@ -340,8 +352,10 @@ export default class List extends Component {
                   key={url}
                 >
                   <td>
-                    <div className="imo-status imo-disabled-override" />
-                    <div>Invalid</div>
+                    <div className="imo-status-wrapper">
+                      <div className="imo-status imo-disabled-override" />
+                      <div>Invalid</div>
+                    </div>
                   </td>
                   <td>{url}</td>
                 </tr>
@@ -356,8 +370,10 @@ export default class List extends Component {
                   key={url}
                 >
                   <td>
-                    <div className="imo-status imo-next-override" />
-                    <div>Pending refresh</div>
+                    <div className="imo-status-wrapper">
+                      <div className="imo-status imo-next-override" />
+                      <div>Pending refresh</div>
+                    </div>
                   </td>
                   <td>{url}</td>
                 </tr>
@@ -372,8 +388,10 @@ export default class List extends Component {
                   key={url}
                 >
                   <td>
-                    <div className="imo-status imo-current-override" />
-                    <div>Override</div>
+                    <div className="imo-status-wrapper">
+                      <div className="imo-status imo-current-override" />
+                      <div>Override</div>
+                    </div>
                   </td>
                   <td>{url}</td>
                 </tr>


### PR DESCRIPTION
Hello,

I have made a small pull request to adjust the style of IMO table. Specifically, when the module name extends to multiple lines, the first column "status" was causing the height to break in comparison to the other columns.

This PR aims to address this issue by modifying the CSS styles to ensure consistent and proper alignment of the columns, regardless of the module name length.

Here is some proven before and after change

Before
[Screencast from 26-05-2023 15:57:42.webm](https://github.com/single-spa/import-map-overrides/assets/30227910/94f69504-f632-48e7-80ad-d855653ff018)
![image](https://github.com/single-spa/import-map-overrides/assets/30227910/fd27089d-30c9-42eb-bacd-39ddb6202df1)


After
![image](https://github.com/single-spa/import-map-overrides/assets/30227910/02ca46a5-1e2a-4d9d-8c95-43404843ed51)
Thank you for considering this contribution to the project.
