### PR TITLE
Removed override on background color in dialog box

### DIFF
--- a/src/ui/import-map-overrides.css
+++ b/src/ui/import-map-overrides.css
@@ -104,7 +104,6 @@
   max-width: 600px;
   margin: 0 auto;
   border: 4px solid navajowhite;
-  background-color: white;
   padding: 1em;
   left: 50%;
   right: auto;


### PR DESCRIPTION
Having browser in dark mode sets text color to white in the dialog box. The css style for .ido-module-dialog sets background color to white, without setting text color to black. This results in white text on white background when the browser is in dark mode.

An alternative fix is to set text color to black at the same time as background color is set to white.