### PR TITLE
Fixed bug with broswer in dark mode. 

### DIFF
--- a/.changeset/ninety-mangos-wave.md
+++ b/.changeset/ninety-mangos-wave.md
@@ -1,0 +1,5 @@
+---
+"import-map-overrides": patch
+---
+
+Fixed bug where editor in darkmode resulted in white text on white background in dialog box, and updated a broken test.

--- a/src/api/js-api.imo.test.js
+++ b/src/api/js-api.imo.test.js
@@ -75,7 +75,7 @@ describe("window.importMapOverrides", () => {
       try {
         const map = await window.importMapOverrides.getDefaultMap();
       } catch (e) {
-        expect(e.message).toEqual("Unexpected token M in JSON at position 0");
+        expect(e.name).toEqual("SyntaxError");
       }
     });
 

--- a/src/ui/import-map-overrides.css
+++ b/src/ui/import-map-overrides.css
@@ -104,7 +104,6 @@
   max-width: 600px;
   margin: 0 auto;
   border: 4px solid navajowhite;
-  background-color: white;
   padding: 1em;
   left: 50%;
   right: auto;


### PR DESCRIPTION
Fixed bug where browser in dark mode resulted in white text on white background in dialog box. 

Also fixed a broken test that specified exact error formatting that was not the formatting given when running with the exact packages in the lockfile.