### PR TITLE
Add style-nonce attribute to import-map-overrides-full element to support use under a Content Security Policy(CSP)

### DIFF
--- a/.changeset/rich-maps-visit.md
+++ b/.changeset/rich-maps-visit.md
@@ -1,0 +1,5 @@
+---
+"import-map-overrides": major
+---
+
+The css for import-map-overrides UI is no longer injected into the main page, but only within the shadow dom for the UI

--- a/.changeset/wild-ties-hunt.md
+++ b/.changeset/wild-ties-hunt.md
@@ -1,0 +1,5 @@
+---
+"import-map-overrides": minor
+---
+
+Add style-nonce attribute to import-map-overrides-full element to support use under a Content Security Policy(CSP)

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -43,6 +43,14 @@ You have three options for the UI, depending on how much you want to customize t
   trigger-position="bottom-left"
 ></import-map-overrides-full>
 
+<!--
+   Optionally supply a nonce that will be added to the style tag used to style the import-map-overrides UI. 
+   This is useful if you are using a Content Security Policy(CSP)
+-->
+<import-map-overrides-full
+  style-nonce="NWFjZDlhNTctYTMzZC00MmZjLWJhYzAtZWJmOWYwNTQ0MTdh"
+></import-map-overrides-full>
+
 <!-- Alternatively, just the black popup itself -->
 <import-map-overrides-popup></import-map-overrides-popup>
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,7 +22,9 @@ export default [
         babelHelpers: "bundled",
       }),
       nodeResolve(),
-      postcss(),
+      postcss({
+        inject: false,
+      }),
       isProduction &&
         terser({
           compress: {

--- a/src/ui/custom-elements.js
+++ b/src/ui/custom-elements.js
@@ -37,13 +37,6 @@ function preactCustomElement(Comp, observedAttributes = []) {
       return observedAttributes;
     }
     attributeChangedCallback(name, oldValue, newValue) {
-      if (name === "style-nonce") {
-        this.styleNonce = newValue;
-        if (this.shadow) {
-          this.shadow.querySelector("style").nonce = this.styleNonce;
-        }
-      }
-
       this.renderWithPreact();
     }
     renderWithPreact() {
@@ -51,8 +44,8 @@ function preactCustomElement(Comp, observedAttributes = []) {
         this.shadow = this.attachShadow({ mode: "open" });
         const style = document.createElement("style");
         style.textContent = styles.toString();
-        if (this.styleNonce) {
-          style.nonce = this.styleNonce;
+        if (this.getAttribute("style-nonce")) {
+          style.setAttribute("nonce", this.getAttribute("style-nonce"));
         }
         this.shadow.appendChild(style);
       } else {

--- a/src/ui/custom-elements.js
+++ b/src/ui/custom-elements.js
@@ -10,6 +10,7 @@ if (window.customElements && !isDisabled) {
     "import-map-overrides-full",
     preactCustomElement(FullUI, [
       "show-when-local-storage",
+      "style-nonce",
       "trigger-position",
     ]),
   );
@@ -35,7 +36,14 @@ function preactCustomElement(Comp, observedAttributes = []) {
     static get observedAttributes() {
       return observedAttributes;
     }
-    attributeChangedCallback() {
+    attributeChangedCallback(name, oldValue, newValue) {
+      if (name === "style-nonce") {
+        this.styleNonce = newValue;
+        if (this.shadow) {
+          this.shadow.querySelector("style").nonce = this.styleNonce;
+        }
+      }
+
       this.renderWithPreact();
     }
     renderWithPreact() {
@@ -43,6 +51,9 @@ function preactCustomElement(Comp, observedAttributes = []) {
         this.shadow = this.attachShadow({ mode: "open" });
         const style = document.createElement("style");
         style.textContent = styles.toString();
+        if (this.styleNonce) {
+          style.nonce = this.styleNonce;
+        }
         this.shadow.appendChild(style);
       } else {
         this.shadow = this.shadowRoot;

--- a/src/ui/custom-elements.js
+++ b/src/ui/custom-elements.js
@@ -36,7 +36,7 @@ function preactCustomElement(Comp, observedAttributes = []) {
     static get observedAttributes() {
       return observedAttributes;
     }
-    attributeChangedCallback(name, oldValue, newValue) {
+    attributeChangedCallback() {
       this.renderWithPreact();
     }
     renderWithPreact() {

--- a/test/embedded-map.html
+++ b/test/embedded-map.html
@@ -1,8 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="style-src 'nonce-adsffdsa78dsaf87a9'"
+    />
     <title>Import Map Overrides test</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -25,6 +29,9 @@
     <script src="https://cdn.jsdelivr.net/npm/systemjs/dist/system.js"></script>
   </head>
   <body>
-    <import-map-overrides-full dev-libs></import-map-overrides-full>
+    <import-map-overrides-full
+      dev-libs
+      style-nonce="adsffdsa78dsaf87a9"
+    ></import-map-overrides-full>
   </body>
 </html>


### PR DESCRIPTION
Enables use of the import-map-overrides UI on a site that uses a strict CSP by providing a style-nonce attribute that can be set with the nonce required by the CSP for style tags.