### PR TITLE
Fix css issue with dialog popups. Resolves #130

### DIFF
--- a/.changeset/light-steaks-boil.md
+++ b/.changeset/light-steaks-boil.md
@@ -1,0 +1,5 @@
+---
+"import-map-overrides": patch
+---
+
+Fix CSS issue with dialogs/popups

--- a/.changeset/tall-ways-marry.md
+++ b/.changeset/tall-ways-marry.md
@@ -1,0 +1,5 @@
+---
+"import-map-overrides": minor
+---
+
+Support for style-nonce attribute on import-map-overrides-popup and import-map-overrides-list custom elements

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -54,8 +54,20 @@ You have three options for the UI, depending on how much you want to customize t
 <!-- Alternatively, just the black popup itself -->
 <import-map-overrides-popup></import-map-overrides-popup>
 
+<!-- Optionally supply a nonce that will be added to the style tag used to style the import-map-overrides UI. 
+   This is useful if you are using a Content Security Policy(CSP) -->
+<import-map-overrides-popup
+  style-nonce="NWFjZDlhNTctYTMzZC00MmZjLWJhYzAtZWJmOWYwNTQ0MTdh"
+></import-map-overrides-popup>
+
 <!-- Or if you only want the actual import map list and UI for overriding -->
 <import-map-overrides-list></import-map-overrides-list>
+
+<!-- Optionally supply a nonce that will be added to the style tag used to style the import-map-overrides UI. 
+   This is useful if you are using a Content Security Policy(CSP) -->
+<import-map-overrides-list
+  style-nonce="NWFjZDlhNTctYTMzZC00MmZjLWJhYzAtZWJmOWYwNTQ0MTdh"
+></import-map-overrides-list>
 
 <!-- Or if you prefer enabling via javascript -->
 <script>

--- a/src/ui/custom-elements.js
+++ b/src/ui/custom-elements.js
@@ -16,11 +16,11 @@ if (window.customElements && !isDisabled) {
   );
   window.customElements.define(
     "import-map-overrides-popup",
-    preactCustomElement(Popup),
+    preactCustomElement(Popup, ["style-nonce"]),
   );
   window.customElements.define(
     "import-map-overrides-list",
-    preactCustomElement(List),
+    preactCustomElement(List, ["style-nonce"]),
   );
 }
 

--- a/src/ui/import-map-overrides.css
+++ b/src/ui/import-map-overrides.css
@@ -74,7 +74,7 @@
 }
 
 .imo-popup .imo-module-dialog {
-  left: calc(50% - 200px);
+  left: calc(50%);
 }
 
 .imo-header {

--- a/src/ui/list/list.component.js
+++ b/src/ui/list/list.component.js
@@ -29,41 +29,6 @@ export default class List extends Component {
   componentWillUnmount() {
     window.removeEventListener("import-map-overrides:change", this.doUpdate);
   }
-  componentDidUpdate(prevProps, prevState) {
-    if (!prevState.dialogModule && this.state.dialogModule) {
-      this.dialogContainer = document.createElement("div");
-      document.body.appendChild(this.dialogContainer);
-      render(
-        <ModuleDialog
-          module={this.state.dialogModule}
-          cancel={this.cancel}
-          updateModuleUrl={this.updateModuleUrl}
-          addNewModule={this.addNewModule}
-        />,
-        this.dialogContainer,
-      );
-    } else if (prevState.dialogModule && !this.state.dialogModule) {
-      render(null, this.dialogContainer);
-      this.dialogContainer.remove();
-      delete this.dialogContainer;
-    }
-
-    if (!prevState.dialogExternalMap && this.state.dialogExternalMap) {
-      this.dialogContainer = document.createElement("div");
-      document.body.appendChild(this.dialogContainer);
-      render(
-        <ExternalImportMap
-          dialogExternalMap={this.state.dialogExternalMap}
-          cancel={this.cancel}
-        />,
-        this.dialogContainer,
-      );
-    } else if (prevState.dialogExternalMap && !this.state.dialogExternalMap) {
-      render(null, this.dialogContainer);
-      this.dialogContainer.remove();
-      delete this.dialogContainer;
-    }
-  }
   render() {
     const overriddenModules = [],
       nextOverriddenModules = [],
@@ -379,6 +344,20 @@ export default class List extends Component {
               ))}
             </tbody>
           </table>
+        )}
+        {this.state.dialogModule && (
+          <ModuleDialog
+            module={this.state.dialogModule}
+            cancel={this.cancel}
+            updateModuleUrl={this.updateModuleUrl}
+            addNewModule={this.addNewModule}
+          />
+        )}
+        {this.state.dialogExternalMap && (
+          <ExternalImportMap
+            dialogExternalMap={this.state.dialogExternalMap}
+            cancel={this.cancel}
+          />
         )}
       </div>
     );

--- a/src/ui/list/list.component.js
+++ b/src/ui/list/list.component.js
@@ -1,4 +1,4 @@
-import { h, Component, render } from "preact";
+import { Component } from "preact";
 import { includes } from "../../util/includes.js";
 import ModuleDialog from "./module-dialog.component";
 import ExternalImportMap from "./external-importmap-dialog.component";


### PR DESCRIPTION
See #130. I don't know why it was being rendered in the main dom - might have been quirks of css with shadow dom in specific browsers at the time. I tested that it looks ok in chrome, safari, and firefox, after this change.