### PR TITLE
Fixed bad redirect url in the popup window

### DIFF
--- a/.changeset/yellow-mice-try.md
+++ b/.changeset/yellow-mice-try.md
@@ -1,0 +1,5 @@
+---
+"import-map-overrides": patch
+---
+
+The url of the documentation reference in the popup pointed to an outdated hijacked repository"

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "6.0.0",
   "main": "dist/import-map-overrides-server.js",
   "type": "module",
-  "repository": "https://github.com/joeldenning/import-map-overrides.git",
-  "author": "Joel Denning <joeldenning@gmail.com>",
+  "repository": "https://github.com/single-spa/import-map-overrides.git",
+  "author": "Jolyn Denning <jolyndenning@gmail.com>",
   "license": "MIT",
   "scripts": {
     "build": "pnpm run clean && cross-env NODE_ENV=production rollup -c",

--- a/src/api/js-api.imo.test.js
+++ b/src/api/js-api.imo.test.js
@@ -75,7 +75,9 @@ describe("window.importMapOverrides", () => {
       try {
         const map = await window.importMapOverrides.getDefaultMap();
       } catch (e) {
-        expect(e.message).toEqual("Unexpected token M in JSON at position 0");
+        expect(e.message).toEqual(
+          "Unexpected token 'M', \"Malformed\" is not valid JSON",
+        );
       }
     });
 

--- a/src/api/js-api.imo.test.js
+++ b/src/api/js-api.imo.test.js
@@ -75,9 +75,7 @@ describe("window.importMapOverrides", () => {
       try {
         const map = await window.importMapOverrides.getDefaultMap();
       } catch (e) {
-        expect(e.message).toEqual(
-          "Unexpected token 'M', \"Malformed\" is not valid JSON",
-        );
+        expect(e.message).toEqual("Unexpected token M in JSON at position 0");
       }
     });
 

--- a/src/ui/popup.component.js
+++ b/src/ui/popup.component.js
@@ -22,7 +22,7 @@ export default class Popup extends Component {
               maps. Start by clicking on a module that you'd like to override.{" "}
               <a
                 target="_blank"
-                href="https://github.com/joeldenning/import-map-overrides"
+                href="https://github.com/single-spa/import-map-overrides"
               >
                 See documentation for more info
               </a>


### PR DESCRIPTION
The url in the popup window for "See documentation for more info" redirected to an outdated hijacked repository.
Changed it to point to this one instead 

Also fixed a failing test