### PR TITLE
Feature use `part` allows custom styling of button

### DIFF
--- a/.changeset/weak-rules-clean.md
+++ b/.changeset/weak-rules-clean.md
@@ -1,0 +1,5 @@
+---
+"import-map-overrides": minor
+---
+
+add 'patch' to the button for external css styling

--- a/.changeset/weak-rules-clean.md
+++ b/.changeset/weak-rules-clean.md
@@ -2,4 +2,4 @@
 "import-map-overrides": minor
 ---
 
-add 'patch' to the button for external css styling
+add 'part' to the button for external css styling

--- a/blob/main/docs/ui.md
+++ b/blob/main/docs/ui.md
@@ -1,8 +1,5 @@
 ## styling the ui button with custom css rules
 
-modern css allows you to style elements in the shadow-dom by using `::part`. you can use the following rules to provide custom styles to the import-map-overrides button
-
-Here is a simple example of how you might apply custom styles
 ```css
 import-map-overrides-full::part(button-with-overrides) {
     /* styles to be applied to the button when overrides are present */

--- a/blob/main/docs/ui.md
+++ b/blob/main/docs/ui.md
@@ -1,17 +1,17 @@
 ## styling the ui button with custom css rules
 
 ```css
-import-map-overrides-full::part(button-with-overrides) {
+import-map-overrides-full::part(button with-overrides) {
     /* styles to be applied to the button when overrides are present */
     color: green;
 }
 
-import-map-overrides-full::part(button-no-overrides) {
+import-map-overrides-full::part(button) {
     /* styles to be applied to the button when overrides are not present */
     color: green;
 }
 
-import-map-overrides-full::part(button-with-overrides):hover {
+import-map-overrides-full::part(button with-overrides):hover {
     /* styles to be applied to the button when overrides are present and it is hovered */
     border: 5px solid black;
 }

--- a/blob/main/docs/ui.md
+++ b/blob/main/docs/ui.md
@@ -6,7 +6,7 @@ import-map-overrides-full::part(button-with-overrides) {
     color: green;
 }
 
-import-map-overrides-full::part(button-no-overrides){
+import-map-overrides-full::part(button-no-overrides) {
     /* styles to be applied to the button when overrides are not present */
     color: green;
 }

--- a/blob/main/docs/ui.md
+++ b/blob/main/docs/ui.md
@@ -14,7 +14,7 @@ import-map-overrides-full::part(button-no-overrides){
     color: green;
 }
 
-import-map-overrides-full::part(button-with-overrides):hover{
+import-map-overrides-full::part(button-with-overrides):hover {
     /* styles to be applied to the button when overrides are present and it is hovered */
     border: 5px solid black;
 }

--- a/blob/main/docs/ui.md
+++ b/blob/main/docs/ui.md
@@ -4,7 +4,7 @@ modern css allows you to style elements in the shadow-dom by using `::part`. you
 
 Here is a simple example of how you might apply custom styles
 ```css
-import-map-overrides-full::part(button-with-overrides){
+import-map-overrides-full::part(button-with-overrides) {
     /* styles to be applied to the button when overrides are present */
     color: green;
 }

--- a/blob/main/docs/ui.md
+++ b/blob/main/docs/ui.md
@@ -1,0 +1,22 @@
+## styling the ui button with custom css rules
+
+modern css allows you to style elements in the shadow-dom by using `::part`. you can use the following rules to provide custom styles to the import-map-overrides button
+
+Here is a simple example of how you might apply custom styles
+```css
+import-map-overrides-full::part(button-with-overrides){
+    /* styles to be applied to the button when overrides are present */
+    color: green;
+}
+
+import-map-overrides-full::part(button-no-overrides){
+    /* styles to be applied to the button when overrides are not present */
+    color: green;
+}
+
+import-map-overrides-full::part(button-with-overrides):hover{
+    /* styles to be applied to the button when overrides are present and it is hovered */
+    border: 5px solid black;
+}
+```
+

--- a/src/ui/full-ui.component.js
+++ b/src/ui/full-ui.component.js
@@ -45,7 +45,6 @@ export default class FullUI extends Component {
     return (
       <div>
         <button
-          {/* you can style this with css `import-map-overrides::part(button-with-override){color:red;}`*/}
           part={this.atLeastOneOverride() ? "button-with-override" : "button-no-override"}
           onClick={this.toggleTrigger}
           className={`imo-unstyled imo-trigger imo-trigger-${triggerPosition} ${

--- a/src/ui/full-ui.component.js
+++ b/src/ui/full-ui.component.js
@@ -45,7 +45,7 @@ export default class FullUI extends Component {
     return (
       <div>
         <button
-          part={`button${this.atLeastOneOverride() ? " with-override" : ""}`}
+          part={`button${this.atLeastOneOverride() ? " with-overrides" : ""}`}
           onClick={this.toggleTrigger}
           className={`imo-unstyled imo-trigger imo-trigger-${triggerPosition} ${
             this.atLeastOneOverride() ? "imo-current-override" : ""

--- a/src/ui/full-ui.component.js
+++ b/src/ui/full-ui.component.js
@@ -45,7 +45,7 @@ export default class FullUI extends Component {
     return (
       <div>
         <button
-          part={this.atLeastOneOverride() ? "button-with-override" : "button-no-override"}
+          part={`button ${this.atLeastOneOverride() ? "with-override" : ""}`}
           onClick={this.toggleTrigger}
           className={`imo-unstyled imo-trigger imo-trigger-${triggerPosition} ${
             this.atLeastOneOverride() ? "imo-current-override" : ""

--- a/src/ui/full-ui.component.js
+++ b/src/ui/full-ui.component.js
@@ -45,6 +45,7 @@ export default class FullUI extends Component {
     return (
       <div>
         <button
+          part={this.atLeastOneOverride() ? "button-with-override" : "button-no-override"}
           onClick={this.toggleTrigger}
           className={`imo-unstyled imo-trigger imo-trigger-${triggerPosition} ${
             this.atLeastOneOverride() ? "imo-current-override" : ""

--- a/src/ui/full-ui.component.js
+++ b/src/ui/full-ui.component.js
@@ -45,7 +45,7 @@ export default class FullUI extends Component {
     return (
       <div>
         <button
-          part={`button ${this.atLeastOneOverride() ? "with-override" : ""}`}
+          part={`button${this.atLeastOneOverride() ? " with-override" : ""}`}
           onClick={this.toggleTrigger}
           className={`imo-unstyled imo-trigger imo-trigger-${triggerPosition} ${
             this.atLeastOneOverride() ? "imo-current-override" : ""

--- a/src/ui/full-ui.component.js
+++ b/src/ui/full-ui.component.js
@@ -45,6 +45,7 @@ export default class FullUI extends Component {
     return (
       <div>
         <button
+          {/* you can style this with css `import-map-overrides::part(button-with-override){color:red;}`*/}
           part={this.atLeastOneOverride() ? "button-with-override" : "button-no-override"}
           onClick={this.toggleTrigger}
           className={`imo-unstyled imo-trigger imo-trigger-${triggerPosition} ${


### PR DESCRIPTION
just adds a `part` attribute to the button to allow some custom styling on the button from outside of the shadow dom using normal css

you can style it as follows
```css
import-map-override-full::part(button-no-overrides){ color: white; }
import-map-override-full::part(button-with-overrides){ color: red; }
```